### PR TITLE
Programmable block argument continued

### DIFF
--- a/Sources/Sandbox.Common/ModAPI/Ingame/IMyProgrammableBlock.cs
+++ b/Sources/Sandbox.Common/ModAPI/Ingame/IMyProgrammableBlock.cs
@@ -9,5 +9,6 @@ namespace Sandbox.ModAPI.Ingame
     {
         bool IsRunning { get; }
         string TerminalRunArgument { get; }
+        bool ClearArgumentOnRun { get; }
     }
 }

--- a/Sources/Sandbox.Common/ObjectBuilders/MyObjectBuilder_MyProgrammableBlock.cs
+++ b/Sources/Sandbox.Common/ObjectBuilders/MyObjectBuilder_MyProgrammableBlock.cs
@@ -18,5 +18,8 @@ namespace Sandbox.Common.ObjectBuilders
 
         [ProtoMember(3)]
         public string DefaultRunArgument = null;
+
+        [ProtoMember(4)]
+        public bool ClearArgumentOnRun = false;
     }
 }

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyProgrammableBlock.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyProgrammableBlock.cs
@@ -93,7 +93,7 @@ namespace Sandbox.Game.Entities.Blocks
             var arg = new MyTerminalControlTextbox<MyProgrammableBlock>("TerminalRunArgument", MySpaceTexts.TerminalControlPanel_RunArgument, MySpaceTexts.TerminalControlPanel_RunArgument_ToolTip);
             arg.Visible = (e) => MyFakes.ENABLE_PROGRAMMABLE_BLOCK && MySession.Static.EnableIngameScripts;
             arg.Getter = (e) => new StringBuilder(e.TerminalRunArgument);
-            arg.Setter = (e, v) => e.TerminalRunArgument = v.ToString();
+            arg.Setter = (e, v) => e.SyncObject.RequestChangeTerminalRunArgument(v.ToString());
             arg.EnterPressed = (b) => b.Run();
             MyTerminalControlFactory.AddControl(arg);
             

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyProgrammableBlock.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyProgrammableBlock.cs
@@ -108,7 +108,7 @@ namespace Sandbox.Game.Entities.Blocks
             runAction.ParameterDefinitions.Add(TerminalActionParameter.Get(string.Empty));
             MyTerminalControlFactory.AddAction(runAction);
 
-            var slaveCheck = new MyTerminalControlCheckbox<MyProgrammableBlock>("ClearArgumentOnRun", MySpaceTexts.Assembler_SlaveMode, MySpaceTexts.Assembler_SlaveMode);
+            var slaveCheck = new MyTerminalControlCheckbox<MyProgrammableBlock>("ClearArgumentOnRun", MySpaceTexts.TerminalControlPanel_ClearArgumentOnRun, MySpaceTexts.TerminalControlPanel_ClearArgumentOnRun_ToolTip);
             slaveCheck.Getter = (x) => x.ClearArgumentOnRun;
             slaveCheck.Setter = (x, v) => x.SyncObject.RequestChangeClearArgumentOnRun(v);
             MyTerminalControlFactory.AddControl(slaveCheck);
@@ -357,7 +357,8 @@ namespace Sandbox.Game.Entities.Blocks
             var programmableBlockBuilder = (MyObjectBuilder_MyProgrammableBlock)objectBuilder;
             m_editorData = m_programData = programmableBlockBuilder.Program;
             m_storageData = programmableBlockBuilder.Storage;
-            this.m_terminalRunArgument = programmableBlockBuilder.DefaultRunArgument;
+            m_terminalRunArgument = programmableBlockBuilder.DefaultRunArgument;
+            ClearArgumentOnRun = programmableBlockBuilder.ClearArgumentOnRun;
 
             this.SyncObject = new MySyncProgrammableBlock(this);
             NeedsUpdate |= MyEntityUpdateEnum.BEFORE_NEXT_FRAME;
@@ -406,6 +407,7 @@ namespace Sandbox.Game.Entities.Blocks
             MyObjectBuilder_MyProgrammableBlock objectBuilder = (MyObjectBuilder_MyProgrammableBlock)base.GetObjectBuilderCubeBlock(copy);
             objectBuilder.Program = this.m_programData;
             objectBuilder.DefaultRunArgument = this.m_terminalRunArgument;
+            objectBuilder.ClearArgumentOnRun = ClearArgumentOnRun;
             if (m_storageField != null && m_instance != null)
             {
                 objectBuilder.Storage = (string)m_storageField.GetValue(m_instance);

--- a/Sources/Sandbox.Game/Game/Entities/Blocks/MyProgrammableBlock.cs
+++ b/Sources/Sandbox.Game/Game/Entities/Blocks/MyProgrammableBlock.cs
@@ -629,5 +629,10 @@ namespace Sandbox.Game.Entities.Blocks
             UpdateEmissivity();
             base.OnEnabledChanged();
         }
+
+        public void RefreshProperties()
+        {
+            this.RaisePropertiesChanged();
+        }
     }
 }

--- a/Sources/Sandbox.Game/Game/Localization/MySpaceTexts.cs
+++ b/Sources/Sandbox.Game/Game/Localization/MySpaceTexts.cs
@@ -9890,7 +9890,7 @@ namespace Sandbox.Game.Localization
         public static readonly MyStringId ControlMenuItemLabel_Dampeners = MyStringId.GetOrCompute("ControlMenuItemLabel_Dampeners");
 
         ///<summary>
-        ///An argument passed to your code when clicking the Run button
+        ///An argument passed to your code when clicking the Run button. Pressing enter here will run the script.
         ///</summary>
         public static readonly MyStringId TerminalControlPanel_RunArgument_ToolTip = MyStringId.GetOrCompute("TerminalControlPanel_RunArgument_ToolTip");
 
@@ -10063,5 +10063,15 @@ namespace Sandbox.Game.Localization
         ///Access control menu to setup panel's buttons
         ///</summary>
         public static readonly MyStringId NotificationHintJoystickPressToOpenButtonPanel = MyStringId.GetOrCompute("NotificationHintJoystickPressToOpenButtonPanel");
+
+        ///<summary>
+        ///Clear argument after running
+        ///</summary>
+        public static readonly MyStringId TerminalControlPanel_ClearArgumentOnRun = MyStringId.GetOrCompute("TerminalControlPanel_ClearArgumentOnRun");
+
+        ///<summary>
+        ///Clears the argument box when clicking the Run button.
+        ///</summary>
+        public static readonly MyStringId TerminalControlPanel_ClearArgumentOnRun_ToolTip = MyStringId.GetOrCompute("TerminalControlPanel_ClearArgumentOnRun_ToolTip");
     }
 }

--- a/Sources/Sandbox.Game/Game/MySyncProgrammableBlock.cs
+++ b/Sources/Sandbox.Game/Game/MySyncProgrammableBlock.cs
@@ -364,6 +364,7 @@ namespace Sandbox.Game.Multiplayer
             if (programmableBlock != null)
             {
                 programmableBlock.ClearArgumentOnRun = msg.ClearArgumentOnRun;
+                programmableBlock.RefreshProperties();
             }
         }
     
@@ -401,6 +402,7 @@ namespace Sandbox.Game.Multiplayer
             if (programmableBlock != null)
             {
                 programmableBlock.TerminalRunArgument = msg.TerminalRunArgument;
+                programmableBlock.RefreshProperties();
             }
         }
     }

--- a/Sources/Sandbox.Game/Game/MySyncProgrammableBlock.cs
+++ b/Sources/Sandbox.Game/Game/MySyncProgrammableBlock.cs
@@ -66,6 +66,15 @@ namespace Sandbox.Game.Multiplayer
     {
         MyProgrammableBlock m_programmableBlock;
 
+        [MessageId(16276, P2PMessageEnum.Reliable)]
+        protected struct ClearArgumentOnRunMsg : IEntityMessage
+        {
+            public long EntityId;
+            public long GetEntityId() { return EntityId; }
+                
+            public BoolBlit ClearArgumentOnRun;
+        }
+        
         [MessageIdAttribute(16277, P2PMessageEnum.Reliable)]
         protected struct OpenEditorMsg : IEntityMessage
         {
@@ -123,15 +132,6 @@ namespace Sandbox.Game.Multiplayer
 
             [ProtoBuf.ProtoMember(3)]
             public bool ClearTerminalArgument;
-        }
-
-        [MessageId(16282, P2PMessageEnum.Reliable)]
-        protected struct ClearArgumentOnRunMsg : IEntityMessage
-        {
-            public long EntityId;
-            public long GetEntityId() { return EntityId; }
-                
-            public BoolBlit ClearArgumentOnRun;
         }
 
         static MySyncProgrammableBlock()

--- a/Sources/Sandbox.Game/Game/MySyncProgrammableBlock.cs
+++ b/Sources/Sandbox.Game/Game/MySyncProgrammableBlock.cs
@@ -133,7 +133,7 @@ namespace Sandbox.Game.Multiplayer
 
         [ProtoBuf.ProtoContract]
         [MessageIdAttribute(16281, P2PMessageEnum.Reliable)]
-        protected struct ProgramRepsonseMsg : IEntityMessage
+        protected struct ProgramResponseMsg : IEntityMessage
         {
             [ProtoBuf.ProtoMember(1)]
             public long EntityId;
@@ -160,7 +160,7 @@ namespace Sandbox.Game.Multiplayer
 
             MySyncLayer.RegisterMessage<RunProgramMsg>(RunProgramRequest, MyMessagePermissions.ToServer, MyTransportMessageEnum.Request);
 
-            MySyncLayer.RegisterMessage<ProgramRepsonseMsg>(ProgramResponeSuccess, MyMessagePermissions.FromServer, MyTransportMessageEnum.Success);
+            MySyncLayer.RegisterMessage<ProgramResponseMsg>(ProgramResponseSuccess, MyMessagePermissions.FromServer, MyTransportMessageEnum.Success);
 
             MySyncLayer.RegisterMessage<ClearArgumentOnRunMsg>(ClearArgumentOnRunRequestCallback, MyMessagePermissions.ToServer, MyTransportMessageEnum.Request);
             MySyncLayer.RegisterMessage<ClearArgumentOnRunMsg>(ClearArgumentOnRunSuccessCallback, MyMessagePermissions.FromServer, MyTransportMessageEnum.Success);
@@ -310,7 +310,7 @@ namespace Sandbox.Game.Multiplayer
             Sync.Layer.SendMessageToServer(ref msg, MyTransportMessageEnum.Request);
         }
 
-        static void ProgramResponeSuccess(ref ProgramRepsonseMsg msg, MyNetworkClient sender)
+        static void ProgramResponseSuccess(ref ProgramResponseMsg msg, MyNetworkClient sender)
         {
             MyEntity entity;
             MyEntities.TryGetEntityById(msg.EntityId, out entity);
@@ -324,7 +324,7 @@ namespace Sandbox.Game.Multiplayer
         }
         public virtual void SendProgramResponseMessage(string response, bool clearTerminalArgument)
         {
-            var msg = new ProgramRepsonseMsg();
+            var msg = new ProgramResponseMsg();
             msg.EntityId = m_programmableBlock.EntityId;
             msg.Response = response;
             msg.ClearTerminalArgument = clearTerminalArgument;
@@ -354,6 +354,7 @@ namespace Sandbox.Game.Multiplayer
             {
                 Sync.Layer.SendMessageToAll(ref msg, MyTransportMessageEnum.Success);
                 programmableBlock.ClearArgumentOnRun = msg.ClearArgumentOnRun;
+                programmableBlock.RefreshProperties();
             }   
         }
 
@@ -392,6 +393,7 @@ namespace Sandbox.Game.Multiplayer
             {
                 Sync.Layer.SendMessageToAll(ref msg, MyTransportMessageEnum.Success);
                 programmableBlock.TerminalRunArgument = msg.TerminalRunArgument;
+                programmableBlock.RefreshProperties();
             }   
         }
 

--- a/Sources/Sandbox.Game/Game/Screens/Terminal/Controls/MyTerminalControlTextbox.cs
+++ b/Sources/Sandbox.Game/Game/Screens/Terminal/Controls/MyTerminalControlTextbox.cs
@@ -28,6 +28,7 @@ namespace Sandbox.Game.Gui
         /// </summary>
         public GetterDelegate Getter;
         public SetterDelegate Setter;
+        public Action<TBlock> EnterPressed;
 
         public readonly MyStringId Title;
         public readonly MyStringId Tooltip;
@@ -43,6 +44,7 @@ namespace Sandbox.Game.Gui
 
         private StringBuilder m_tmpText = new StringBuilder(15);
         private Action<MyGuiControlTextbox> m_textChanged;
+        private Action<MyGuiControlTextbox> m_enterPressed;
 
         public MyTerminalControlTextbox(string id, MyStringId title, MyStringId tooltip)
             : base(id)
@@ -55,8 +57,10 @@ namespace Sandbox.Game.Gui
         {
             m_textbox = new MyGuiControlTextbox();
             m_textbox.Size = new Vector2(PREFERRED_CONTROL_WIDTH, m_textbox.Size.Y);
+            m_enterPressed = OnEnterPressed;
             m_textChanged = OnTextChanged;
             m_textbox.TextChanged += m_textChanged;
+            m_textbox.EnterPressed += m_enterPressed;
 
             var propertyControl = new MyGuiControlBlockProperty(MyTexts.GetString(Title), MyTexts.GetString(Tooltip), m_textbox);
             propertyControl.Size = new Vector2(PREFERRED_CONTROL_WIDTH, propertyControl.Size.Y);
@@ -64,6 +68,14 @@ namespace Sandbox.Game.Gui
             return propertyControl;
         }
 
+        void OnEnterPressed(MyGuiControlTextbox obj)
+        {
+            foreach (var item in TargetBlocks)
+            {
+                EnterPressed(item);
+            }
+        }
+        
         void OnTextChanged(MyGuiControlTextbox obj)
         {
             m_tmpText.Clear();

--- a/Sources/SpaceEngineers/Content/Data/Localization/MyTexts.resx
+++ b/Sources/SpaceEngineers/Content/Data/Localization/MyTexts.resx
@@ -6133,7 +6133,7 @@ To connect to lasers not listed here you can connect to coordinates.</value>
     <value>Dampeners</value>
   </data>
   <data name="TerminalControlPanel_RunArgument_ToolTip" xml:space="preserve">
-    <value>An argument passed to your code when clicking the Run button</value>
+    <value>An argument passed to your code when clicking the Run button. Pressing enter here will run the script.</value>
   </data>
   <data name="ControlMenuItemLabel_Helmet" xml:space="preserve">
     <value>Helmet</value>
@@ -6236,5 +6236,11 @@ To connect to lasers not listed here you can connect to coordinates.</value>
   </data>
   <data name="NotificationHintJoystickPressToOpenButtonPanel" xml:space="preserve">
     <value>Access control menu to setup panel's buttons</value>
+  </data>
+  <data name="TerminalControlPanel_ClearArgumentOnRun" xml:space="preserve">
+    <value>Clear argument after running</value>
+  </data>
+  <data name="TerminalControlPanel_ClearArgumentOnRun_ToolTip" xml:space="preserve">
+    <value>Clears the argument box when clicking the Run button.</value>
   </data>
 </root>


### PR DESCRIPTION
Finishing off the programmable block argument feature by running the script when you press enter in the Argument text box, and adding a check box to have the argument removed once the program has run in order to create console like programs.

Also fixed some network messages which didn't work properly for the argument.